### PR TITLE
fmt: no more builtin modules

### DIFF
--- a/dasfmt.das
+++ b/dasfmt.das
@@ -1,7 +1,7 @@
 options gen2
 options indenting = 4
 
-require fio
+require daslib/fio
 require strings
 require math
 

--- a/fs.das
+++ b/fs.das
@@ -1,9 +1,9 @@
 options gen2
 options indenting = 4
 
-module fs shared
+module fs
 
-require fio
+require daslib/fio
 require strings
 require uriparser
 

--- a/log.das
+++ b/log.das
@@ -1,12 +1,12 @@
 options gen2
 options indenting = 4
 
-module log shared
+module log
 
-require rtti
+require daslib/rtti
 require uriparser
 require strings
-require fio
+require daslib/fio
 
 
 let private verbose = false


### PR DESCRIPTION
Builtin modules were moved to daslib/ folder on daScript master.

All usages of them (like `require fio`) should be replaced to `require daslib/fio`.