### PR TITLE
Fix tuple literals after upstream named-tuple strictness

### DIFF
--- a/dasfmt.das
+++ b/dasfmt.das
@@ -29,7 +29,7 @@ def private collect_diff(before, after : string) : tuple<differ : bool; log : st
 
     // If identical after normalization, no differences
     if (normalized_before == normalized_after) {
-        return (false, "")
+        return (differ = false, log = "")
     }
 
     // Split into lines for line-by-line comparison
@@ -57,7 +57,7 @@ def private collect_diff(before, after : string) : tuple<differ : bool; log : st
         }
     }
 
-    return (true, diff_output)
+    return (differ = true, log = diff_output)
 }
 
 def private collect_input_paths(args : array<string>; key : string; var paths : array<string>) {


### PR DESCRIPTION
Upstream daslang ([GaijinEntertainment/daScript#2565](https://github.com/GaijinEntertainment/daScript/pull/2565)) made tuple field names part of the type identity. After that change, the positional tuple literals returned from `collect_diff` no longer match the declared return type `tuple<differ:bool;log:string>`:

```
error[30102]: incompatible return type; tuple<differ:bool;log:string> = tuple<bool;string>
    return (false, "")
    return (true, diff_output)
```

Switch both returns to named-field form: `(differ = false, log = "")` / `(differ = true, log = diff_output)`.